### PR TITLE
Correct variable for term insert error message

### DIFF
--- a/src/Context/Terms/WordPressTermTrait.php
+++ b/src/Context/Terms/WordPressTermTrait.php
@@ -19,7 +19,7 @@ trait WordPressTermTrait
         $term_ids = wp_insert_term($termData['name'], $taxonomy, $termData);
         if (is_wp_error($term_ids)) {
             throw new \InvalidArgumentException(
-                sprintf("Invalid taxonomy term information schema: %s", $return->get_error_message())
+                sprintf("Invalid taxonomy term information schema: %s", $term_ids->get_error_message())
             );
         }
         return $term_ids;


### PR DESCRIPTION
`$return` was used prior to 061ee419f52; should now be `$term_ids`