### PR TITLE
Remove redundant call to wp_set_object_terms()

### DIFF
--- a/src/Context/PostTypes/WordPressPostContext.php
+++ b/src/Context/PostTypes/WordPressPostContext.php
@@ -62,9 +62,8 @@ class WordPressPostContext implements Context
             }
             $terms[] = $term->slug;
         }
-        $term_ids = wp_set_object_terms($post->ID, $terms, $taxonomy, false);
 
-        $this->assignPostTypeTerms($post, $taxonomy, $term_ids);
+        $this->assignPostTypeTerms($post, $taxonomy, $terms);
     }
     
     


### PR DESCRIPTION
`wp_set_object_terms()` was called twice: once in this file, and once in the inherited function `assignPostTypeTerms()`. As `wp_set_object_terms()` can accept ids or slugs, `$terms` can be passed directly to `assignPostTypeTerms()`. Either line 65 or 67 could be removed, but I am keeping the latter, as it includes some exception handling.

I only spotted this because there was an issue with this code in my test environment (WP 4.7.2). `$term_ids` returned by the first call to `wp_set_object_terms()` was an array of strings, which were being interpreted as slugs, as warned about [here](https://codex.wordpress.org/Function_Reference/wp_set_object_terms#Parameters), causing the new terms with title and slug of "2" and "3" (ids of my actual terms) to be created and assigned to the post.